### PR TITLE
New function 'Reset_SOILWAT2_after_UnitTest' for unit testing

### DIFF
--- a/test/sw_maintest.cc
+++ b/test/sw_maintest.cc
@@ -35,7 +35,7 @@
 
 #include "../SW_Control.h"
 
-
+#include "sw_testhelpers.h"
 
 
 /* The unit test code is using the SOILWAT2-standalone input files from testing/ as
@@ -55,9 +55,9 @@ extern Bool QuietMode, EchoInits;
 extern char _firstfile[];
 
 
+
 int main(int argc, char **argv) {
   int res;
-
   /*--- Imitate 'SW_Main.c/main()': we need to initialize and take down SOILWAT2 variables
     because SOILWAT2 uses (global) states. This is otherwise not comptable with the c++
     approach used by googletest.
@@ -74,8 +74,7 @@ int main(int argc, char **argv) {
   EchoInits = FALSE;
 
   // Initialize SOILWAT2 variables and read values from example input file
-	SW_CTL_init_model(_firstfile);
-	SW_CTL_obtain_inputs();
+  Reset_SOILWAT2_after_UnitTest();
 
   //--- Setup and call unit tests
   ::testing::InitGoogleTest(&argc, argv);

--- a/test/sw_testhelpers.cc
+++ b/test/sw_testhelpers.cc
@@ -1,0 +1,46 @@
+#include "gtest/gtest.h"
+#include <assert.h>
+#include <ctype.h>
+#include <dirent.h>
+#include <errno.h>
+#include <float.h>
+#include <math.h>
+#include <memory.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "../generic.h"
+#include "../myMemory.h"
+#include "../filefuncs.h"
+#include "../rands.h"
+#include "../Times.h"
+#include "../SW_Defines.h"
+#include "../SW_Times.h"
+#include "../SW_Files.h"
+#include "../SW_Carbon.h"
+#include "../SW_Site.h"
+#include "../SW_VegProd.h"
+#include "../SW_VegEstab.h"
+#include "../SW_Model.h"
+#include "../SW_SoilWater.h"
+#include "../SW_Weather.h"
+#include "../SW_Markov.h"
+#include "../SW_Sky.h"
+#include "../SW_Control.h"
+
+#include "sw_testhelpers.h"
+
+extern char _firstfile[];
+
+/** Initialize SOILWAT2 variables and read values from example input file
+ */
+void Reset_SOILWAT2_after_UnitTest(void) {
+  SW_CTL_init_model(_firstfile);
+  SW_CTL_obtain_inputs();
+}

--- a/test/sw_testhelpers.h
+++ b/test/sw_testhelpers.h
@@ -1,0 +1,4 @@
+#include "gtest/gtest.h"
+
+
+void Reset_SOILWAT2_after_UnitTest(void);

--- a/test/test_SW_Carbon.cc
+++ b/test/test_SW_Carbon.cc
@@ -35,6 +35,8 @@
 #include "../SW_Markov.h"
 #include "../SW_Sky.h"
 
+#include "sw_testhelpers.h"
+
 
 extern SW_CARBON SW_Carbon;
 extern SW_MODEL SW_Model;
@@ -58,8 +60,7 @@ namespace {
     EXPECT_EQ(typeid(x), typeid(c->use_bio_mult));
 
     // Reset to previous global state
-    SW_CBN_read();
-    calculate_CO2_multipliers();
+    Reset_SOILWAT2_after_UnitTest();
   }
 
 
@@ -95,9 +96,7 @@ namespace {
     }
 
     // Reset to previous global state
-    SW_CBN_construct();
-    SW_CBN_read();
-    calculate_CO2_multipliers();
+    Reset_SOILWAT2_after_UnitTest();
   }
 
 
@@ -126,15 +125,8 @@ namespace {
       EXPECT_GT(v->tree.co2_multipliers[WUE_INDEX][year], 0.);
     }
 
-
     // Reset to previous global states
-    SW_CBN_construct();
-    SW_VPD_construct();
-
-    SW_CBN_read();
-    SW_VPD_read();
-
-    calculate_CO2_multipliers();
+    Reset_SOILWAT2_after_UnitTest();
   }
 
 } // namespace

--- a/test/test_SW_VegProd.cc
+++ b/test/test_SW_VegProd.cc
@@ -33,6 +33,8 @@
 #include "../SW_Markov.h"
 #include "../SW_Sky.h"
 
+#include "sw_testhelpers.h"
+
 
 extern SW_MODEL SW_Model;
 extern SW_VEGPROD SW_VegProd;
@@ -64,9 +66,7 @@ namespace {
     EXPECT_DOUBLE_EQ(1., v->forb.co2_multipliers[WUE_INDEX][MAX_NYEAR - 1]);
 
     // Reset to previous global state
-    SW_VPD_construct();
-    SW_VPD_read();
-    calculate_CO2_multipliers();
+    Reset_SOILWAT2_after_UnitTest();
   }
 
 


### PR DESCRIPTION
- close #113 

- function 'Reset_SOILWAT2_after_UnitTest' reads in data from all input
files and initializes all variables as if SOILWAT2 would start up --
somewhat expensive but thorough (time to run current unit tests
increased from about 10 ms to about 30 ms)

- call 'Reset_SOILWAT2_after_UnitTest' at the end of each TEST